### PR TITLE
Avoid compiler warnings

### DIFF
--- a/d64write/stb_image.h
+++ b/d64write/stb_image.h
@@ -5080,7 +5080,7 @@ static int stbi__parse_png_file(stbi__png *z, int scan, int req_comp)
 {
    stbi_uc palette[1024], pal_img_n=0;
    stbi_uc has_trans=0, tc[3]={0};
-   stbi__uint16 tc16[3];
+   stbi__uint16 tc16[3]={0};
    stbi__uint32 ioff=0, idata_limit=0, i, pal_len=0;
    int first=1,k,interlace=0, color=0, is_iphone=0;
    stbi__context *s = z->s;


### PR DESCRIPTION
This is a somewhat untested change, but it makes sense. The initialization of tc16 is made in a similar way as the initialization of tc3 is done.