### PR TITLE
Update link_macros_kickass.inc to follow KickAss syntax

### DIFF
--- a/macros/link_macros_kickass.inc
+++ b/macros/link_macros_kickass.inc
@@ -238,23 +238,23 @@ l:
 		}
 
 		.macro crt_request_disk (arg) {
-			:setup_sync() arg
+			:setup_sync(arg)
 l:
 			lda #$7f			//space pressed?
 			sta $dc00
 			lda $dc01
 			and #$10
-			beq .e				//yes, exit
+			beq e				//yes, exit
 			lda link_frame_count + 1	//check counter
-			bpl +
-			sta .f + 1
-:()
+			bpl !+
+			sta f + 1
+!:
 			lda #$fd			//shift lock pressed?
 			sta $dc00
 			lda $dc01
-.f			and #$00
+f:			and #$00
 			bpl l				//shift lock pressed or not expired
-.e
+e:
 		}
 
 		.macro skip_file () {


### PR DESCRIPTION
Without these changes, the code does not compile. With these changes, the code compiles.

The changes are untested. But they look like they follow the intent of the original code.